### PR TITLE
fix: Prevent 404 and update repo name

### DIFF
--- a/dist/js/good-first-issue.js
+++ b/dist/js/good-first-issue.js
@@ -64,10 +64,11 @@ function createCommentSVG() {
 
 async function fetchRepoIssues(repo) {
     const issueRes = await fetch(`https://api.github.com/repos/${repo.full_name}/issues`);
-    let issues = issueRes.status === 200
-        ? await issueRes.json()
-        : []
+    if (issueRes.status !== 200) {
+        return;
+    }
 
+    let issues = await issueRes.json();
     issues = issues.filter((i) => !i.pull_request);
     issues = issues.filter((i) => (i?.labels || []).find(l => l.name === 'good first issue'));
     if (issues.length === 0) {

--- a/dist/js/good-first-issue.js
+++ b/dist/js/good-first-issue.js
@@ -64,9 +64,7 @@ function createCommentSVG() {
 
 async function fetchRepoIssues(repo) {
     const issueRes = await fetch(`https://api.github.com/repos/${repo.full_name}/issues`);
-    let issues = await issueRes.json();
-
-    issues = issueRes.ok 
+    let issues = issueRes.status === 200
         ? await issueRes.json()
         : []
 

--- a/dist/js/repos.js
+++ b/dist/js/repos.js
@@ -64,8 +64,8 @@ const   yearnRepos = [
           "name": "yearn-exporter"
       },  
       {
-        "full_name": "yearn-data-analytics",
-        "name": "yearn-data-analytics"
+        "full_name": "ydata",
+        "name": "ydata"
       },
       {
           "full_name": "yearn/yearn-devdocs",
@@ -82,10 +82,6 @@ const   yearnRepos = [
       {
           "full_name": "yearn/yearn-api",
           "name": "yearn-api"
-      },
-      {
-          "full_name": "yearn-data-analytics",
-          "name": "yearn-data-analytics"
       },
       {
         "full_name": "yearn/brownie-strategy-mix",

--- a/dist/js/repos.js
+++ b/dist/js/repos.js
@@ -64,7 +64,7 @@ const   yearnRepos = [
           "name": "yearn-exporter"
       },  
       {
-        "full_name": "ydata",
+        "full_name": "yearn/ydata",
         "name": "ydata"
       },
       {

--- a/repos.json
+++ b/repos.json
@@ -64,8 +64,8 @@
           "name": "yearn-exporter"
       },  
       {
-        "full_name": "yearn-data-analytics",
-        "name": "yearn-data-analytics"
+        "full_name": "ydata",
+        "name": "ydata"
       },
       {
           "full_name": "yearn/yearn-devdocs",
@@ -82,10 +82,6 @@
       {
           "full_name": "yearn/yearn-api",
           "name": "yearn-api"
-      },
-      {
-          "full_name": "yearn-data-analytics",
-          "name": "yearn-data-analytics"
       },
       {
         "full_name": "yearn/brownie-strategy-mix",

--- a/repos.json
+++ b/repos.json
@@ -64,7 +64,7 @@
           "name": "yearn-exporter"
       },  
       {
-        "full_name": "ydata",
+        "full_name": "yearn/ydata",
         "name": "ydata"
       },
       {


### PR DESCRIPTION
Fixes https://github.com/yearn/yearn-issues/issues/17

## Description

* `yearn-data-analytics` was renamed `ydata` and for that reason we were getting a 404;
* Check if we get a 200 before requesting JSON.

## Reviewers

@DarkGhost7 @Majorfi